### PR TITLE
build examples in ci

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -6,6 +6,14 @@ main() {
     if [ $TRAVIS_RUST_VERSION = nightly ]; then
         cargo check --features spanned --target $T
     fi
+
+    if [ $T = x86_64-unknown-linux-gnu ]; then
+        cargo build --examples --target $T
+
+        if [ $TRAVIS_RUST_VERSION = nightly ]; then
+            cargo build --examples --target $T --features spanned
+        fi
+    fi
 }
 
 # fake Travis variables to be able to run this on a local machine

--- a/examples/global.rs
+++ b/examples/global.rs
@@ -1,6 +1,10 @@
-extern crate stlog;
+#![cfg_attr(feature = "spanned", feature(proc_macro_hygiene))]
 
-use stlog::{error, global_logger, info, GlobalLog};
+#[cfg(feature = "spanned")]
+use stlog::spanned::{error, info, trace};
+#[cfg(not(feature = "spanned"))]
+use stlog::{error, info};
+use stlog::{global_logger, GlobalLog};
 
 struct Logger;
 
@@ -13,5 +17,7 @@ static LOGGER: Logger = Logger;
 
 fn main() {
     info!("Hello!");
+    #[cfg(feature = "spanned")]
+    trace!("Hello!");
     error!("Bye!");
 }

--- a/examples/local.rs
+++ b/examples/local.rs
@@ -1,13 +1,18 @@
-extern crate stlog;
+#![cfg_attr(feature = "spanned", feature(proc_macro_hygiene))]
 
-use stlog::{error, info, Log};
+#[cfg(feature = "spanned")]
+use stlog::spanned::{error, info, trace};
+use stlog::Log;
+#[cfg(not(feature = "spanned"))]
+use stlog::{error, info};
 
 struct Logger;
 
 impl Log for Logger {
     type Error = ();
 
-    fn log(&mut self, _: u8) -> Result<(), ()> {
+    fn log(&mut self, byte: u8) -> Result<(), ()> {
+        println!("{}", byte);
         Ok(())
     }
 }
@@ -15,6 +20,8 @@ impl Log for Logger {
 fn main() {
     let mut logger = Logger;
 
-    info!(logger, "Hello!");
-    error!(logger, "Bye!");
+    info!(logger, "Hello!").unwrap();
+    #[cfg(feature = "spanned")]
+    trace!(logger, "Hello!").unwrap();
+    error!(logger, "Bye!").unwrap();
 }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -44,24 +44,13 @@ pub fn global_logger(args: TokenStream, input: TokenStream) -> TokenStream {
     let ty = var.ty;
     let expr = var.expr;
 
-    // TODO use this when rust-lang/rust#54451 lands
-    // quote!(
-    //     #(#attrs)*
-    //     #vis static #ident: #ty = {
-    //         #[export_name = "stlog::GLOBAL_LOGGER"]
-    //         static __STLOGGER__: &stlog::GlobalLog = &#ident;
-
-    //         #expr
-    //     };
-    // ).into()
-
     quote!(
         #(#attrs)*
-        #vis static #ident: #ty = #expr;
+        #vis static #ident: #ty = {
+            #[export_name = "stlog::GLOBAL_LOGGER"]
+            static GLOBAL_LOGGER: &stlog::GlobalLog = &#ident;
 
-        #[export_name = "stlog::GLOBAL_LOGGER"]
-        pub static __STLOG_GLOBAL_LOGGER__: &(stlog::GlobalLog) = {
-            &#ident
+            #expr
         };
     )
     .into()


### PR DESCRIPTION
also update `#[global_logger]` to not pollute its surrounding namespace with a
random static variable